### PR TITLE
feat(routes): add hw8 route

### DIFF
--- a/src/routes/hw8/category.ts
+++ b/src/routes/hw8/category.ts
@@ -1,0 +1,15 @@
+import { Context } from 'hono';
+
+import { namespace } from './namespace';
+
+import { CategoryRoute } from '@/types';
+import { handler } from '@/utils/cms/category';
+
+export const route: CategoryRoute = {
+    path: '/category',
+    name: 'category',
+    example: '/hw8/category',
+    description: `获取分类列表`,
+    handler: (ctx: Context) => handler(ctx, namespace),
+    method: 'POST'
+};

--- a/src/routes/hw8/detail.ts
+++ b/src/routes/hw8/detail.ts
@@ -1,0 +1,15 @@
+import { Context } from 'hono';
+
+import { namespace } from './namespace';
+
+import { DetailRoute } from '@/types';
+import { handler } from '@/utils/cms/detail';
+
+export const route: DetailRoute = {
+    path: '/detail',
+    name: 'detail',
+    example: '/hw8/detail',
+    description: `获取详情`,
+    handler: (ctx: Context) => handler(ctx, namespace),
+    method: 'POST'
+};

--- a/src/routes/hw8/home.ts
+++ b/src/routes/hw8/home.ts
@@ -1,0 +1,14 @@
+import { Context } from 'hono';
+
+import { namespace } from './namespace';
+
+import { HomeRoute } from '@/types';
+import { handler } from '@/utils/cms/home';
+
+export const route: HomeRoute = {
+    path: '/home',
+    name: 'home',
+    example: '/hw8/home',
+    description: `首页分类列表`,
+    handler: (ctx: Context) => handler(ctx, namespace)
+};

--- a/src/routes/hw8/homeVod.ts
+++ b/src/routes/hw8/homeVod.ts
@@ -1,0 +1,14 @@
+import { Context } from 'hono';
+
+import { namespace } from './namespace';
+
+import { HomeVodRoute } from '@/types';
+import { handler } from '@/utils/cms/homeVod';
+
+export const route: HomeVodRoute = {
+    path: '/homeVod',
+    name: 'homeVod',
+    example: '/hw8/homeVod',
+    description: `最近更新`,
+    handler: (ctx: Context) => handler(ctx, namespace)
+};

--- a/src/routes/hw8/namespace.ts
+++ b/src/routes/hw8/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '华为吧资源',
+    url: 'https://hw8.live',
+    description: '华为吧资源'
+};

--- a/src/routes/hw8/play.ts
+++ b/src/routes/hw8/play.ts
@@ -1,0 +1,15 @@
+import { Context } from 'hono';
+
+import { namespace } from './namespace';
+
+import { PlayRoute } from '@/types';
+import { handler } from '@/utils/cms/play';
+
+export const route: PlayRoute = {
+    path: '/play',
+    name: 'play',
+    example: '/hw8/play',
+    description: `获取播放地址`,
+    handler: (ctx: Context) => handler(ctx, namespace),
+    method: 'POST'
+};

--- a/src/routes/hw8/search.ts
+++ b/src/routes/hw8/search.ts
@@ -1,0 +1,15 @@
+import { Context } from 'hono';
+
+import { namespace } from './namespace';
+
+import { SearchRoute } from '@/types';
+import { handler } from '@/utils/cms/search';
+
+export const route: SearchRoute = {
+    path: '/search',
+    name: 'search',
+    example: '/hw8/search',
+    description: `关键词搜索`,
+    handler: (ctx: Context) => handler(ctx, namespace),
+    method: 'POST'
+};


### PR DESCRIPTION
新增华为吧资源路由

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增华为吧资源路由：`/category`、`/detail`、`/home`、`/homeVod`、`/play`、`/search`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->