### PR TITLE
feat(routes): add bfzy route

### DIFF
--- a/src/routes/bfzy/category.ts
+++ b/src/routes/bfzy/category.ts
@@ -1,0 +1,15 @@
+import { Context } from 'hono';
+
+import { namespace } from './namespace';
+
+import { CategoryRoute } from '@/types';
+import { handler } from '@/utils/cms/category';
+
+export const route: CategoryRoute = {
+    path: '/category',
+    name: 'category',
+    example: '/bfzy/category',
+    description: `获取分类列表`,
+    handler: (ctx: Context) => handler(ctx, namespace),
+    method: 'POST'
+};

--- a/src/routes/bfzy/detail.ts
+++ b/src/routes/bfzy/detail.ts
@@ -1,0 +1,15 @@
+import { Context } from 'hono';
+
+import { namespace } from './namespace';
+
+import { DetailRoute } from '@/types';
+import { handler } from '@/utils/cms/detail';
+
+export const route: DetailRoute = {
+    path: '/detail',
+    name: 'detail',
+    example: '/bfzy/detail',
+    description: `获取详情`,
+    handler: (ctx: Context) => handler(ctx, namespace),
+    method: 'POST'
+};

--- a/src/routes/bfzy/home.ts
+++ b/src/routes/bfzy/home.ts
@@ -1,0 +1,14 @@
+import { Context } from 'hono';
+
+import { namespace } from './namespace';
+
+import { HomeRoute } from '@/types';
+import { handler } from '@/utils/cms/home';
+
+export const route: HomeRoute = {
+    path: '/home',
+    name: 'home',
+    example: '/bfzy/home',
+    description: `首页分类列表`,
+    handler: (ctx: Context) => handler(ctx, namespace)
+};

--- a/src/routes/bfzy/homeVod.ts
+++ b/src/routes/bfzy/homeVod.ts
@@ -1,0 +1,14 @@
+import { Context } from 'hono';
+
+import { namespace } from './namespace';
+
+import { HomeVodRoute } from '@/types';
+import { handler } from '@/utils/cms/homeVod';
+
+export const route: HomeVodRoute = {
+    path: '/homeVod',
+    name: 'homeVod',
+    example: '/bfzy/homeVod',
+    description: `最近更新`,
+    handler: (ctx: Context) => handler(ctx, namespace)
+};

--- a/src/routes/bfzy/namespace.ts
+++ b/src/routes/bfzy/namespace.ts
@@ -1,0 +1,7 @@
+import type { Namespace } from '@/types';
+
+export const namespace: Namespace = {
+    name: '暴风资源',
+    url: 'https://bfzyapi.com',
+    description: '暴风资源'
+};

--- a/src/routes/bfzy/play.ts
+++ b/src/routes/bfzy/play.ts
@@ -1,0 +1,15 @@
+import { Context } from 'hono';
+
+import { namespace } from './namespace';
+
+import { PlayRoute } from '@/types';
+import { handler } from '@/utils/cms/play';
+
+export const route: PlayRoute = {
+    path: '/play',
+    name: 'play',
+    example: '/bfzy/play',
+    description: `获取播放地址`,
+    handler: (ctx: Context) => handler(ctx, namespace),
+    method: 'POST'
+};

--- a/src/routes/bfzy/search.ts
+++ b/src/routes/bfzy/search.ts
@@ -1,0 +1,15 @@
+import { Context } from 'hono';
+
+import { namespace } from './namespace';
+
+import { SearchRoute } from '@/types';
+import { handler } from '@/utils/cms/search';
+
+export const route: SearchRoute = {
+    path: '/search',
+    name: 'search',
+    example: '/bfzy/search',
+    description: `关键词搜索`,
+    handler: (ctx: Context) => handler(ctx, namespace),
+    method: 'POST'
+};

--- a/src/utils/cms/category/index.ts
+++ b/src/utils/cms/category/index.ts
@@ -16,7 +16,7 @@ export const handler = async (ctx: Context, namespace) => {
         const { id, page, filters } = body;
         // filters: { class, area, lang, year }
 
-        let res = await request.post<CMSDetailData>(`${namespace.url}/api.php/provide/vod`, {
+        let res = await request.get<CMSDetailData>(`${namespace.url}/api.php/provide/vod`, {
             params: {
                 ac: 'detail',
                 t: id,

--- a/src/utils/cms/search/index.ts
+++ b/src/utils/cms/search/index.ts
@@ -17,7 +17,7 @@ export const handler = async (ctx: Context, namespace) => {
 
         const { keyword } = body;
 
-        const res = await request.post<CMSDetailData>(`${namespace.url}/api.php/provide/vod`, {
+        const res = await request.get<CMSDetailData>(`${namespace.url}/api.php/provide/vod`, {
             params: {
                 ac: 'detail',
                 wd: keyword


### PR DESCRIPTION
新增暴风资源路由

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
	- 添加了暴风资源（BFZY）的多个路由，包括：
		- 类别路由
		- 详情路由
		- 主页路由
		- 主页视频路由
		- 播放路由
		- 搜索路由

- **改进**
	- 修改了类别和搜索功能的请求方法，从 POST 改为 GET

- **基础设施**
	- 新增命名空间配置，定义了资源相关信息

<!-- end of auto-generated comment: release notes by coderabbit.ai -->